### PR TITLE
Bump for kotlin-gradle-plugin and Gradle versions.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.jhomlala.alice'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.21'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
It is requested by latest Android Studio (stable channel) with Kotlin and latest Gradle version:
Android Studio 3.3.2
Build #AI-182.5107.16.33.5314842, built on February 16, 2019
JRE: 1.8.0_152-release-1248-b01 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
macOS 10.14.3

Build fails with:
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.0 and higher.
The following dependencies do not satisfy the required version:
project ':alice' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.71

