### PR TITLE
Added NavigatorKey injection

### DIFF
--- a/lib/alice.dart
+++ b/lib/alice.dart
@@ -14,8 +14,8 @@ class Alice {
   AliceHttpAdapter _httpAdapter;
   bool showNotification = true;
 
-  Alice({this.showNotification = true}) {
-    _navigatorKey = GlobalKey<NavigatorState>();
+  Alice({this.showNotification = true, GlobalKey<NavigatorState> navigatorKey}) {
+    _navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>();
     _core = AliceCore(_navigatorKey, showNotification);
     _httpClientAdapter = AliceHttpClientAdapter(_core);
     _httpAdapter = AliceHttpAdapter(_core);


### PR DESCRIPTION
Added a navigator key in the constructor so the user is not forced to use the navigator key created by alice.
This makes it easier to integrate alice in an app that already uses a navigator key.