### PR TITLE
add query parameters to dio interceptor;

### DIFF
--- a/lib/core/alice_dio_interceptor.dart
+++ b/lib/core/alice_dio_interceptor.dart
@@ -45,6 +45,7 @@ class AliceDioInterceptor extends InterceptorsWrapper {
     request.headers = options.headers;
     request.contentType = options.contentType.toString();
     request.cookies = options.cookies;
+    request.queryParameters = options.queryParameters;
 
     call.request = request;
     call.response = AliceHttpResponse();

--- a/lib/model/alice_http_request.dart
+++ b/lib/model/alice_http_request.dart
@@ -7,4 +7,5 @@ class AliceHttpRequest {
   dynamic body = "";
   String contentType = "";
   List<Cookie> cookies = List();
+  Map<String, dynamic> queryParameters = Map();
 }

--- a/lib/ui/alice_call_details_screen.dart
+++ b/lib/ui/alice_call_details_screen.dart
@@ -96,6 +96,18 @@ class _AliceCallDetailsScreenState extends State<AliceCallDetailsScreen>
     }
     rows.add(_getListRow("Body:", bodyContent));
 
+    var queryParameters = widget.call.request.queryParameters;
+    var queryParametersContent = "Query parameters are empty";
+    if (queryParameters != null && queryParameters.length > 0) {
+      queryParametersContent = "";
+    }
+    rows.add(_getListRow("Query Parameters: ", queryParametersContent));
+    if (widget.call.request.queryParameters != null) {
+      widget.call.request.queryParameters.forEach((k, value) {
+        rows.add(_getListRow("   • $k:", value.toString()));
+      });
+    }
+
     var headers = widget.call.request.headers;
     var headersContent = "Headers are empty";
     if (headers != null && headers.length > 0) {


### PR DESCRIPTION
Thanks for the library, this is incredibly useful!

I am using the dio interceptor and found that surfacing request query parameters was missing. I made the change in my fork and figured I'd throw a PR upstream in case you wanted to use it.

Cheers,
Matt