### PR TITLE
Added shake option to show inspector from everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.17
+* Added shake option to open inspector from everywhere
+
 ## 0.0.16
 * Fixed server text overflow
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 <img src="https://raw.githubusercontent.com/jhomlala/alice/master/media/logo.png">
 </p>
 
-
 # Alice
+
 [![pub package](https://img.shields.io/pub/v/alice.svg)](https://pub.dartlang.org/packages/alice)
 [![pub package](https://img.shields.io/github/license/jhomlala/alice.svg?style=flat)](https://github.com/jhomlala/alice)
 [![pub package](https://img.shields.io/badge/platform-flutter-blue.svg)](https://github.com/jhomlala/alice)
 
 Alice is an HTTP Inspector tool for Flutter which helps debugging http requests. It catches and stores http requests and responses, which can be viewed via simple UI. It is inspired from Chuck ( https://github.com/jgilfelt/chuck ).
+
 <p align="center">
 <img height="500" src="https://github.com/jhomlala/comptf2/blob/master/media/appsmaller.gif">
 </p>
@@ -48,9 +49,10 @@ Alice is an HTTP Inspector tool for Flutter which helps debugging http requests.
 </table>
 
 **Suported Dart http client plugins:**
-* Dio
-* HttpClient from dart:io package
-* Http from http/http package 
+
+- Dio
+- HttpClient from dart:io package
+- Http from http/http package
 
 **Features:**  
 ✔️ Detailed logs for each HTTP calls (HTTP Request, HTTP Response)  
@@ -60,49 +62,67 @@ Alice is an HTTP Inspector tool for Flutter which helps debugging http requests.
 ✔️ Notification on HTTP call  
 ✔️ Support for top used HTTP clients in Dart  
 ✔️ Error handling  
-  
+✔️ Shake to open inspector
 
 ## Install
+
 1. Add this to your **pubspec.yaml** file:
+
 ```yaml
 dependencies:
   alice: ^0.0.16
 ```
+
 2. Install it
+
 ```bash
 $ flutter packages get
 ```
 
 3. Import it
+
 ```dart
 import 'package:alice/alice.dart';
 ```
 
 ## Usage
+
 Create Alice instance:
+
 ```dart
 Alice alice = Alice(showNotification: true);
 ```
+
 Alice default behaviour is to show notification with http requests. You can disable it in `Alice` constructor.
 
 Add navigator key to your application:
+
 ```dart
 MaterialApp( navigatorKey: alice.getNavigatorKey(), home: ...)
 ```
+
 You need to add this navigator key in order to show inspector UI.
 You can use also your navigator key in Alice:
+
 ```dart
 Alice alice = Alice(showNotification: true, navigatorKey: yourNavigatorKeyHere);
 ```
 
+You can set `showInspectorOnShake` in Alice constructor to open inspector by shaking your device (default disabled):
+
+```dart
+Alice alice = Alice(showNotification: true, showInspectorOnShake: true, navigatorKey: yourNavigatorKeyHere);
+```
 
 If you're using Dio, you just need to add interceptor.
+
 ```dart
 Dio dio = Dio();
 dio.interceptors.add(alice.getDioInterceptor());
 ```
 
 If you're using HttpClient from dart:io package:
+
 ```dart
 httpClient
 	.getUrl(Uri.parse("https://jsonplaceholder.typicode.com/posts"))
@@ -115,6 +135,7 @@ httpClient
 ```
 
 If you're using http from http/http package:
+
 ```dart
 http.get('https://jsonplaceholder.typicode.com/posts').then((response) {
     alice.onHttpResponse(response);
@@ -122,10 +143,13 @@ http.get('https://jsonplaceholder.typicode.com/posts').then((response) {
 ```
 
 To show inspector manually:
+
 ```dart
 alice.showInspector();
 ```
+
 ## Saving calls
+
 Alice supports saving logs to your mobile device storage. In order to make save feature works, you need to add in your Android application manifest:
 
 ```xml
@@ -133,5 +157,5 @@ Alice supports saving logs to your mobile device storage. In order to make save 
 ```
 
 ## Example
-See complete example here: https://github.com/jhomlala/alice/blob/master/example/lib/main.dart
 
+See complete example here: https://github.com/jhomlala/alice/blob/master/example/lib/main.dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,7 +20,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void initState() {
-    alice = Alice(showNotification: true);
+    alice = Alice(showNotification: true, showInspectorOnShake: true);
     dio = Dio();
     dio.interceptors.add(alice.getDioInterceptor());
     httpClient = HttpClient();
@@ -144,9 +144,8 @@ class _MyAppState extends State<MyApp> {
     });
 
     dio.post("https://jsonplaceholder.typicode.com/posts", data: body);
-    dio.get("https://jsonplaceholder.typicode.com/posts", queryParameters: {
-      "test":1
-    });
+    dio.get("https://jsonplaceholder.typicode.com/posts",
+        queryParameters: {"test": 1});
     dio.put("https://jsonplaceholder.typicode.com/posts/1", data: body);
     dio.put("https://jsonplaceholder.typicode.com/posts/1", data: body);
     dio.delete("https://jsonplaceholder.typicode.com/posts/1");

--- a/lib/alice.dart
+++ b/lib/alice.dart
@@ -12,12 +12,16 @@ class Alice {
   AliceCore _core;
   AliceHttpClientAdapter _httpClientAdapter;
   AliceHttpAdapter _httpAdapter;
-  bool showNotification = true;
+  bool showNotification;
+  bool showInspectorOnShake;
 
-  Alice(
-      {this.showNotification = true, GlobalKey<NavigatorState> navigatorKey}) {
+  Alice({
+    this.showNotification = true,
+    GlobalKey<NavigatorState> navigatorKey,
+    this.showInspectorOnShake = false,
+  }) {
     _navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>();
-    _core = AliceCore(_navigatorKey, showNotification);
+    _core = AliceCore(_navigatorKey, showNotification, showInspectorOnShake);
     _httpClientAdapter = AliceHttpClientAdapter(_core);
     _httpAdapter = AliceHttpAdapter(_core);
   }

--- a/lib/core/alice_core.dart
+++ b/lib/core/alice_core.dart
@@ -34,7 +34,7 @@ class AliceCore {
       _initializeNotificationsPlugin();
     }
     _showInspectorOnShake = showInspectorOnShake;
-    if (showInspectorOnShake) {
+    if (_showInspectorOnShake) {
       shakeDetector = ShakeDetector.autoStart(
         onPhoneShake: () => navigateToCallListScreen(),
         shakeThresholdGravity: 5,

--- a/lib/core/alice_core.dart
+++ b/lib/core/alice_core.dart
@@ -6,17 +6,25 @@ import 'package:alice/ui/alice_save_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:shake/shake.dart';
 
 class AliceCore {
   FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin;
   GlobalKey<NavigatorState> _navigatorKey;
   bool _showNotification = false;
+  bool _showInspectorOnShake = false;
+  bool _isInspectorOpened = false;
 
   List<AliceHttpCall> calls;
   PublishSubject<int> changesSubject;
   PublishSubject<AliceHttpCall> callUpdateSubject;
+  ShakeDetector shakeDetector;
 
-  AliceCore(GlobalKey<NavigatorState> navigatorKey, bool showNotification) {
+  AliceCore(
+    GlobalKey<NavigatorState> navigatorKey,
+    bool showNotification,
+    bool showInspectorOnShake,
+  ) {
     _navigatorKey = navigatorKey;
     calls = List();
     changesSubject = PublishSubject();
@@ -25,11 +33,19 @@ class AliceCore {
     if (showNotification) {
       _initializeNotificationsPlugin();
     }
+    _showInspectorOnShake = showInspectorOnShake;
+    if (showInspectorOnShake) {
+      shakeDetector = ShakeDetector.autoStart(
+        onPhoneShake: () => navigateToCallListScreen(),
+        shakeThresholdGravity: 5,
+      );
+    }
   }
 
   dispose() {
     changesSubject.close();
     callUpdateSubject.close();
+    shakeDetector?.stopListening();
   }
 
   void _initializeNotificationsPlugin() {
@@ -54,10 +70,13 @@ class AliceCore {
       print(
           "Cant start Alice HTTP Inspector. Please add NavigatorKey to your application");
     }
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (context) => AliceCallsListScreen(this)),
-    );
+    if (!_isInspectorOpened) {
+      _isInspectorOpened = true;
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => AliceCallsListScreen(this)),
+      ).then((onValue) => _isInspectorOpened = false);
+    }
   }
 
   BuildContext getContext() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   permission_handler: ^3.2.2
   package_info: ^0.4.0+6
   open_file: ^2.0.3
+  shake: ^0.1.0
 
 dev_dependencies:
-
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
@@ -34,7 +34,6 @@ flutter:
   plugin:
     androidPackage: com.jhomlala.alice
     pluginClass: AlicePlugin
-
   # To add assets to your plugin package, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg
@@ -45,7 +44,6 @@ flutter:
   #
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.io/assets-and-images/#resolution-aware.
-
   # To add custom fonts to your plugin package, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a


### PR DESCRIPTION
Inspired from https://github.com/kasketis/netfox library.
I've added the possibility of showing the inspector from everywhere in the app by shaking the device. So that no buttons needed.
ShakeListener is disabled in default Alice's constructor.