### PR TITLE
Fix double-encoding of request body if request body is a minified json

### DIFF
--- a/lib/ui/alice_base_call_details_widget.dart
+++ b/lib/ui/alice_base_call_details_widget.dart
@@ -41,7 +41,10 @@ abstract class AliceBaseCallDetailsWidget extends StatelessWidget {
       } else {
         if (body is String && body.contains("\n")) {
           bodyContent = body;
-        } else {
+        } else if(body is String){
+          //body is minified json, so decode it to a map and let the encoder pretty print this map
+          bodyContent = encoder.convert(json.decode(body));
+        } else{
           bodyContent = encoder.convert(body);
         }
       }

--- a/lib/ui/alice_call_request_widget.dart
+++ b/lib/ui/alice_call_request_widget.dart
@@ -13,12 +13,12 @@ class AliceCallRequestWidget extends AliceBaseCallDetailsWidget {
     List<Widget> rows = List();
     rows.add(getListRow("Started:", call.request.time.toString()));
     rows.add(getListRow("Bytes sent:", formatBytes(call.request.size)));
-    rows.add(getListRow("Content type:", call.request.contentType));
+    rows.add(getListRow("Content type:", getContentType(call.request.headers)));
 
     var body = call.request.body;
     var bodyContent = "Body is empty";
     if (body != null && body.length > 0) {
-      bodyContent = encoder.convert(call.request.body);
+      bodyContent = formatBody(body, getContentType(call.request.headers));
     }
     rows.add(getListRow("Body:", bodyContent));
 


### PR DESCRIPTION
Currently, if the request body is a minified json string, alice will encode it again as json, causing the body to be encoded as json twice, resulting in a lot of unnecessary escape characters.

See this screenshot: https://photos.app.goo.gl/c8ktAxS9ToRQjUt26

This PR fixes this.