### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.24
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.0.23
 * Updated to dart 2.6.0
 * Added AliceHttpExtensions, AliceHttpClientExtensions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alice
 description: Alice is an HTTP Inspector tool which helps debugging http requests. It catches and stores http requests and responses, which can be viewed via simple UI.
-version: 0.0.23
+version: 0.0.24
 author: Jakub Homlala <jhomlala@gmail.com>
 homepage: https://github.com/jhomlala/alice
 
@@ -16,7 +16,7 @@ dependencies:
   rxdart: ^0.23.1
   path_provider: ^1.6.0
   permission_handler: ^4.0.0
-  package_info: ^0.4.0+13
+  package_info: '>=0.4.0+13 <2.0.0'
   open_file: ^3.0.1
   shake: ^0.1.0
   share: ^0.6.3+5


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).