### PR TITLE
Increase the number of lines displayed in endpoint

### DIFF
--- a/lib/ui/widget/alice_call_list_item_widget.dart
+++ b/lib/ui/widget/alice_call_list_item_widget.dart
@@ -59,7 +59,7 @@ class AliceCallListItemWidget extends StatelessWidget {
           // ignore: avoid_unnecessary_containers
           child: Container(
             child: Text(
-              call.endpoint,
+              call.endpoint.breakWord,
               overflow: TextOverflow.ellipsis,
               maxLines: 4,
               style: TextStyle(
@@ -221,5 +221,18 @@ class AliceCallListItemWidget extends StatelessWidget {
         size: 12,
       ),
     );
+  }
+}
+
+// Workaround to prevent unexpected line breaks
+// https://github.com/flutter/flutter/issues/61081
+extension on String {
+  String get breakWord {
+    String breakWord = '';
+    runes.forEach((element) {
+      breakWord += String.fromCharCode(element);
+      breakWord += '\u200B';
+    });
+    return breakWord;
   }
 }

--- a/lib/ui/widget/alice_call_list_item_widget.dart
+++ b/lib/ui/widget/alice_call_list_item_widget.dart
@@ -46,6 +46,7 @@ class AliceCallListItemWidget extends StatelessWidget {
   Widget _buildMethodAndEndpointRow(BuildContext context) {
     final Color? textColor = _getEndpointTextColor(context);
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           call.method,
@@ -60,6 +61,7 @@ class AliceCallListItemWidget extends StatelessWidget {
             child: Text(
               call.endpoint,
               overflow: TextOverflow.ellipsis,
+              maxLines: 4,
               style: TextStyle(
                 fontSize: 16,
                 color: textColor,


### PR DESCRIPTION
The maxLines of Endpoint has been increased to 4 lines. af1025b
This is because if the base path of the Endpoint is long, it will be omitted as the same Endpoint in the Inspector's list, making it difficult to find the desired request.

By the way, the reason it's 4 lines is because that's what [Chucker does](https://github.com/ChuckerTeam/chucker/blob/33a12b1075eda2af2e62d50058d15f92934cd9d0/library/src/main/res/layout/chucker_list_item_transaction.xml#L35).

before|after
--|--
<img src="https://user-images.githubusercontent.com/2616299/150469950-44538647-834f-459b-b1c1-4c93c9ce4953.png" width=250>|<img src="https://user-images.githubusercontent.com/2616299/150470170-2abf9315-e42f-4ac1-a3dd-13a1fa44af8b.png" width=250>

Added a workaround for unexpected line breaks that make it difficult to see the Endpoint display. c5cd75b

before|after
--|--
<img src="https://user-images.githubusercontent.com/2616299/150470245-5a34bddd-5f12-4c42-90c0-696e39d58f71.png" width=250>|<img src="https://user-images.githubusercontent.com/2616299/150470235-bc322dab-275d-423e-b2f9-c0ce5e2da363.png" width=250>

