### PR TITLE
change default duration from 0 to calculate by begin & end time

### DIFF
--- a/lib/core/alice_http_adapter.dart
+++ b/lib/core/alice_http_adapter.dart
@@ -83,7 +83,8 @@ class AliceHttpAdapter {
     call.response = httpResponse;
 
     call.loading = false;
-    call.duration = 0;
+    call.duration = httpResponse.time.millisecondsSinceEpoch -
+        httpRequest.time!.millisecondsSinceEpoch;
     aliceCore.addCall(call);
   }
 }


### PR DESCRIPTION
i have 0 ms when use "alice.onHttpResponse(response);" 
