### PR TITLE
fix-navigator-pop-using-alice-with-custom-navigation-key

### DIFF
--- a/lib/helper/alice_alert_helper.dart
+++ b/lib/helper/alice_alert_helper.dart
@@ -13,24 +13,28 @@ class AliceAlertHelper {
     Function? secondButtonAction,
   }) {
     final actions = <Widget>[
-      TextButton(
-        onPressed: () {
-          // ignore: avoid_dynamic_calls
-          firstButtonAction?.call();
-          Navigator.of(context).pop();
-        },
-        child: Text(firstButtonTitle),
+      Builder(
+        builder: (context) => TextButton(
+          onPressed: () {
+            // ignore: avoid_dynamic_calls
+            firstButtonAction?.call();
+            Navigator.of(context).pop();
+          },
+          child: Text(firstButtonTitle),
+        ),
       ),
     ];
     if (secondButtonTitle != null) {
       actions.add(
-        TextButton(
-          onPressed: () {
-            // ignore: avoid_dynamic_calls
-            secondButtonAction?.call();
-            Navigator.of(context).pop();
-          },
-          child: Text(secondButtonTitle),
+        Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              // ignore: avoid_dynamic_calls
+              secondButtonAction?.call();
+              Navigator.of(context).pop();
+            },
+            child: Text(secondButtonTitle),
+          ),
         ),
       );
     }

--- a/lib/ui/page/alice_calls_list_screen.dart
+++ b/lib/ui/page/alice_calls_list_screen.dart
@@ -513,18 +513,22 @@ class _AliceCallsListScreenState extends State<AliceCallsListScreen>
               },
             ),
             actions: [
-              TextButton(
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-                child: const Text('Cancel'),
+              Builder(
+                builder: (context) => TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('Cancel'),
+                ),
               ),
-              TextButton(
-                onPressed: () {
-                  Navigator.of(context).pop();
-                  sortCalls();
-                },
-                child: const Text('Use filter'),
+              Builder(
+                builder: (context) => TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    sortCalls();
+                  },
+                  child: const Text('Use filter'),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
This PR just wrap 4 buttons with a Builder widget to get the closest context available for the Navigator.pop call.
When using custom navigator key on my app, i've seen that Alice showDialog action button poped the entire alice screen instead of the dialog.

But wrapping these buttons with a Builder the issue is well fixed.