### PR TITLE
Add identifer to NotificationResponse.payload so alice's notification can be filtered in notification listener.

### DIFF
--- a/lib/core/alice_core.dart
+++ b/lib/core/alice_core.dart
@@ -235,7 +235,7 @@ class AliceCore {
       'Alice (total: ${callsSubject.value.length} requests)',
       message,
       platformChannelSpecifics,
-      payload: '',
+      payload: 'alice-inspector',
     );
     _notificationMessageShown = message;
     _notificationProcessing = false;


### PR DESCRIPTION
This PR adds a string to NotificationResponse.payload that sent to the apps that utilize alice package. This string is useful when we have our own onTapped/onClicked listener for the foreground notification.  

You can see the complete issue [here](https://stackoverflow.com/questions/77980869/flutter-package-alice-inspector-not-showing-along-with-custom-foreground-notifi).

I propose this implementation so that later I can implement this filtering inside my foreground notification listener.
```Dart
_notificationsPlugin.initialize(initializationSettings,
        onDidReceiveNotificationResponse: (payload) async {
      if (payload.payload == "alice-inspector" && !kReleaseMode) {
        alice.showInspector();
      } else {
        // my custom notification listener goes here
      }
    });
```

At first I just want to filter the alice notification by using `if (payload.payload.isEmpty && !kReleaseMode)` since alice sent an empty string to NotificationResponse.payload. However, later I think that it's a bad idea to do so, since other native may also sent an empty string as payload.