### PR TITLE
fix: alice_chopper interceptor

### DIFF
--- a/packages/alice_chopper/lib/alice_chopper_response_interceptor.dart
+++ b/packages/alice_chopper/lib/alice_chopper_response_interceptor.dart
@@ -3,7 +3,6 @@ import 'dart:convert' show utf8;
 import 'dart:io' show HttpHeaders;
 
 import 'package:alice/core/alice_adapter.dart';
-import 'package:alice/core/alice_core.dart';
 import 'package:alice/core/alice_utils.dart';
 import 'package:alice/model/alice_http_call.dart';
 import 'package:alice/model/alice_http_request.dart';
@@ -11,13 +10,7 @@ import 'package:alice/model/alice_http_response.dart';
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
 
-class AliceChopperInterceptor with AliceAdapter implements Interceptor {
-  /// AliceCore instance
-  final AliceCore aliceCore;
-
-  /// Creates instance of chopper interceptor
-  AliceChopperInterceptor(this.aliceCore);
-
+class AliceChopperAdapter with AliceAdapter implements Interceptor {
   /// Creates hashcode based on request
   int getRequestHashCode(http.BaseRequest baseRequest) {
     final int hashCodeSum = baseRequest.url.hashCode +

--- a/packages/alice_chopper/lib/alice_chopper_response_interceptor.dart
+++ b/packages/alice_chopper/lib/alice_chopper_response_interceptor.dart
@@ -2,6 +2,7 @@ import 'dart:async' show FutureOr;
 import 'dart:convert' show utf8;
 import 'dart:io' show HttpHeaders;
 
+import 'package:alice/core/alice_adapter.dart';
 import 'package:alice/core/alice_core.dart';
 import 'package:alice/core/alice_utils.dart';
 import 'package:alice/model/alice_http_call.dart';
@@ -10,7 +11,7 @@ import 'package:alice/model/alice_http_response.dart';
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
 
-class AliceChopperInterceptor implements Interceptor {
+class AliceChopperInterceptor with AliceAdapter implements Interceptor {
   /// AliceCore instance
   final AliceCore aliceCore;
 
@@ -23,7 +24,7 @@ class AliceChopperInterceptor implements Interceptor {
         baseRequest.method.hashCode +
         (baseRequest.headers.entries
             .map((MapEntry<String, String> header) =>
-        header.key.hashCode + header.value.hashCode)
+                header.key.hashCode + header.value.hashCode)
             .reduce((int value, int hashCode) => value + hashCode)) +
         (baseRequest.contentLength?.hashCode ?? 0);
 
@@ -33,7 +34,8 @@ class AliceChopperInterceptor implements Interceptor {
   /// Handles chopper request and creates alice http call
   @override
   FutureOr<Response<BodyType>> intercept<BodyType>(
-      Chain<BodyType> chain,) async {
+    Chain<BodyType> chain,
+  ) async {
     final Response<BodyType> response = await chain.proceed(chain.request);
 
     try {
@@ -42,16 +44,13 @@ class AliceChopperInterceptor implements Interceptor {
           applyHeader(
             chain.request,
             'alice_token',
-            DateTime
-                .now()
-                .millisecondsSinceEpoch
-                .toString(),
+            DateTime.now().millisecondsSinceEpoch.toString(),
           ),
         ),
       )
         ..method = chain.request.method
         ..endpoint =
-        chain.request.url.path.isEmpty ? '/' : chain.request.url.path
+            chain.request.url.path.isEmpty ? '/' : chain.request.url.path
         ..server = chain.request.url.host
         ..secure = chain.request.url.scheme == 'https'
         ..uri = chain.request.url.toString()
@@ -65,9 +64,7 @@ class AliceChopperInterceptor implements Interceptor {
           ..body = '';
       } else {
         aliceHttpRequest
-          ..size = utf8
-              .encode(chain.request.body as String)
-              .length
+          ..size = utf8.encode(chain.request.body as String).length
           ..body = chain.request.body;
       }
       aliceHttpRequest
@@ -88,14 +85,12 @@ class AliceChopperInterceptor implements Interceptor {
           ..status = response.statusCode
           ..body = response.body ?? ''
           ..size = response.body != null
-              ? utf8
-              .encode(response.body.toString())
-              .length
+              ? utf8.encode(response.body.toString()).length
               : 0
           ..time = DateTime.now()
           ..headers = <String, String>{
             for (final MapEntry<String, String> entry
-            in response.headers.entries)
+                in response.headers.entries)
               entry.key: entry.value
           });
 

--- a/packages/alice_chopper/lib/alice_chopper_response_interceptor.dart
+++ b/packages/alice_chopper/lib/alice_chopper_response_interceptor.dart
@@ -1,7 +1,8 @@
-import 'dart:async';
-import 'dart:convert';
+import 'dart:async' show FutureOr;
+import 'dart:convert' show utf8;
+import 'dart:io' show HttpHeaders;
 
-import 'package:alice/core/alice_adapter.dart';
+import 'package:alice/core/alice_core.dart';
 import 'package:alice/core/alice_utils.dart';
 import 'package:alice/model/alice_http_call.dart';
 import 'package:alice/model/alice_http_request.dart';
@@ -9,130 +10,100 @@ import 'package:alice/model/alice_http_response.dart';
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
 
-class AliceChopperAdapter with AliceAdapter implements Interceptor {
+class AliceChopperInterceptor implements Interceptor {
+  /// AliceCore instance
+  final AliceCore aliceCore;
+
+  /// Creates instance of chopper interceptor
+  AliceChopperInterceptor(this.aliceCore);
+
   /// Creates hashcode based on request
   int getRequestHashCode(http.BaseRequest baseRequest) {
-    var hashCodeSum = 0;
-    hashCodeSum += baseRequest.url.hashCode;
-    hashCodeSum += baseRequest.method.hashCode;
-    if (baseRequest.headers.isNotEmpty) {
-      baseRequest.headers.forEach((key, value) {
-        hashCodeSum += key.hashCode;
-        hashCodeSum += value.hashCode;
-      });
-    }
-    if (baseRequest.contentLength != null) {
-      hashCodeSum += baseRequest.contentLength.hashCode;
-    }
+    final int hashCodeSum = baseRequest.url.hashCode +
+        baseRequest.method.hashCode +
+        (baseRequest.headers.entries
+            .map((MapEntry<String, String> header) =>
+        header.key.hashCode + header.value.hashCode)
+            .reduce((int value, int hashCode) => value + hashCode)) +
+        (baseRequest.contentLength?.hashCode ?? 0);
 
     return hashCodeSum.hashCode;
   }
 
   /// Handles chopper request and creates alice http call
-  Future<Request> interceptRequest(Request request) async {
+  @override
+  FutureOr<Response<BodyType>> intercept<BodyType>(
+      Chain<BodyType> chain,) async {
+    final Response<BodyType> response = await chain.proceed(chain.request);
+
     try {
-      final headers = request.headers;
-      headers['alice_token'] = DateTime.now().millisecondsSinceEpoch.toString();
-      final changedRequest = request.copyWith(headers: headers);
-      final baseRequest = await changedRequest.toBaseRequest();
-
-      final call = AliceHttpCall(getRequestHashCode(baseRequest));
-      var endpoint = '';
-      var server = '';
-
-      final split = request.url.toString().split('/');
-      if (split.length > 2) {
-        server = split[1] + split[2];
-      }
-      if (split.length > 4) {
-        endpoint = '/';
-        for (var splitIndex = 3; splitIndex < split.length; splitIndex++) {
-          // ignore: use_string_buffers
-          endpoint += '${split[splitIndex]}/';
-        }
-        endpoint = endpoint.substring(0, endpoint.length - 1);
-      }
-
-      call
-        ..method = request.method
-        ..endpoint = endpoint
-        ..server = server
+      final AliceHttpCall call = AliceHttpCall(
+        getRequestHashCode(
+          applyHeader(
+            chain.request,
+            'alice_token',
+            DateTime
+                .now()
+                .millisecondsSinceEpoch
+                .toString(),
+          ),
+        ),
+      )
+        ..method = chain.request.method
+        ..endpoint =
+        chain.request.url.path.isEmpty ? '/' : chain.request.url.path
+        ..server = chain.request.url.host
+        ..secure = chain.request.url.scheme == 'https'
+        ..uri = chain.request.url.toString()
         ..client = 'Chopper';
-      if (request.url.toString().contains('https')) {
-        call.secure = true;
-      }
 
-      final aliceHttpRequest = AliceHttpRequest();
+      final AliceHttpRequest aliceHttpRequest = AliceHttpRequest();
 
-      if (request.body == null) {
+      if (chain.request.body == null) {
         aliceHttpRequest
           ..size = 0
           ..body = '';
       } else {
         aliceHttpRequest
-          ..size = utf8.encode(request.body as String).length
-          ..body = request.body;
+          ..size = utf8
+              .encode(chain.request.body as String)
+              .length
+          ..body = chain.request.body;
       }
       aliceHttpRequest
         ..time = DateTime.now()
-        ..headers = request.headers;
+        ..headers = chain.request.headers;
 
       String? contentType = 'unknown';
-      if (request.headers.containsKey('Content-Type')) {
-        contentType = request.headers['Content-Type'];
+      if (chain.request.headers.containsKey(HttpHeaders.contentTypeHeader)) {
+        contentType = chain.request.headers[HttpHeaders.contentTypeHeader];
       }
       aliceHttpRequest
         ..contentType = contentType
-        ..queryParameters = request.parameters;
+        ..queryParameters = chain.request.parameters;
 
       call
         ..request = aliceHttpRequest
-        ..response = AliceHttpResponse();
+        ..response = (AliceHttpResponse()
+          ..status = response.statusCode
+          ..body = response.body ?? ''
+          ..size = response.body != null
+              ? utf8
+              .encode(response.body.toString())
+              .length
+              : 0
+          ..time = DateTime.now()
+          ..headers = <String, String>{
+            for (final MapEntry<String, String> entry
+            in response.headers.entries)
+              entry.key: entry.value
+          });
 
       aliceCore.addCall(call);
-      return changedRequest;
     } catch (exception) {
       AliceUtils.log(exception.toString());
-      return request;
-    }
-  }
-
-  /// Handles chopper response and adds data to existing alice http call
-  @override
-  // ignore: strict_raw_type
-  void interceptResponse(Response response) {
-    final httpResponse = AliceHttpResponse()..status = response.statusCode;
-    if (response.body == null) {
-      httpResponse
-        ..body = ''
-        ..size = 0;
-    } else {
-      httpResponse
-        ..body = response.body
-        ..size = utf8.encode(response.body.toString()).length;
     }
 
-    httpResponse.time = DateTime.now();
-    final headers = <String, String>{};
-    response.headers.forEach((header, values) {
-      headers[header] = values;
-    });
-    httpResponse.headers = headers;
-
-    if (response.base.request != null) {
-      aliceCore.addResponse(
-        httpResponse,
-        getRequestHashCode(response.base.request!),
-      );
-    }
-  }
-
-  @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(
-      Chain<BodyType> chain) async {
-    final request = await interceptRequest(chain.request);
-    final response = await chain.proceed(request);
-    interceptResponse(response);
     return response;
   }
 }


### PR DESCRIPTION
This PR supersedes #180

---

Hey 👋

Recently I stumbled upon this awesome package and I noticed it (also) uses [Chopper](https://pub.dev/packages/chopper) [Interceptors](https://hadrien-lejard.gitbook.io/chopper/interceptors).

In [Chopper v8.0.0](https://pub.dev/packages/chopper/changelog#800), there was a significant [restructuring of interceptors](https://github.com/lejard-h/chopper/pull/547). The `RequestInterceptor` and `ResponseInterceptor` classes, as well as their function counterparts, were removed.

Since I'm one of the [maintainers of Chopper](https://github.com/lejard-h/chopper?tab=readme-ov-file#contributors-) I thought I'd contribute to this library by updating the `AliceChopperInterceptor` to be compatible with Chopper v8.0.0.

CC / @Guldem

---

✅ I tested the provided Alice Chopper example on an Android Simulator.