### PR TITLE
fix: package dependency overrides

### DIFF
--- a/packages/alice_chopper/pubspec_overrides.yaml
+++ b/packages/alice_chopper/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
 # melos_managed_dependency_overrides: alice
 dependency_overrides:
   alice:
-    path: ..\\alice
+    path: ../alice

--- a/packages/alice_dio/pubspec_overrides.yaml
+++ b/packages/alice_dio/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
 # melos_managed_dependency_overrides: alice
 dependency_overrides:
   alice:
-    path: ..\\alice
+    path: ../alice

--- a/packages/alice_http/pubspec_overrides.yaml
+++ b/packages/alice_http/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
 # melos_managed_dependency_overrides: alice
 dependency_overrides:
   alice:
-    path: ..\\alice
+    path: ../alice

--- a/packages/alice_http_client/pubspec_overrides.yaml
+++ b/packages/alice_http_client/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
 # melos_managed_dependency_overrides: alice
 dependency_overrides:
   alice:
-    path: ..\\alice
+    path: ../alice


### PR DESCRIPTION
I noticed that the dependency overrides of the packages used `\\` instead of `/` so I fixed them.