### PR TITLE
fix: packages/alice_chopper non-HTTP error status

### DIFF
--- a/packages/alice_chopper/lib/alice_chopper_adapter.dart
+++ b/packages/alice_chopper/lib/alice_chopper_adapter.dart
@@ -103,7 +103,7 @@ class AliceChopperAdapter with AliceAdapter implements Interceptor {
 
       /// Add empty response to Alice core
       aliceCore.addResponse(
-        AliceHttpResponse(),
+        AliceHttpResponse()..status = -1,
         requestId,
       );
 


### PR DESCRIPTION
I noticed that the `AliceHttpResponse.status` has to be `-1` to show `ERR` in the calls list UI.

![image](https://github.com/jhomlala/alice/assets/1174328/b4451627-6ae1-48bc-bb05-0c506128b026)
