### PR TITLE
fix/wrong-navigator-used:  _onBackPressed use the wrong navigator.

### DIFF
--- a/packages/alice/lib/ui/calls_list/page/alice_calls_list_page.dart
+++ b/packages/alice/lib/ui/calls_list/page/alice_calls_list_page.dart
@@ -166,7 +166,7 @@ class _AliceCallsListPageState extends State<AliceCallsListPage>
   /// Called when back button has been pressed. It navigates back to original
   /// application.
   void _onBackPressed() {
-    Navigator.of(context, rootNavigator: true).pop();
+    Navigator.of(context).pop();
   }
 
   /// Called when clear logs has been pressed. It displays dialog and awaits for

--- a/packages/alice/lib/ui/common/alice_dialog.dart
+++ b/packages/alice/lib/ui/common/alice_dialog.dart
@@ -17,7 +17,7 @@ class AliceGeneralDialog {
   }) =>
       showDialog<void>(
         context: context,
-        builder: (BuildContext buildContext) {
+        builder: (BuildContext context) {
           return Theme(
             data: AliceTheme.getTheme(),
             child: AlertDialog(


### PR DESCRIPTION
_onBackPressed use rootNavigator: true.

When using `alice.setNavigatorKey(navigatorKey)` the code using `using rootNavigator: true` will use the root navigator of the app instead of the one gave from setNavigatorKey. That lead to some black screen (because root page removed) or wrong root removal.

This property should be removed as this PR did.