### PR TITLE
fix-dio-query-parameters

### DIFF
--- a/packages/alice_dio/lib/alice_dio_adapter.dart
+++ b/packages/alice_dio/lib/alice_dio_adapter.dart
@@ -79,7 +79,7 @@ class AliceDioAdapter extends InterceptorsWrapper with AliceAdapter {
       ..time = DateTime.now()
       ..headers = AliceParser.parseHeaders(headers: options.headers)
       ..contentType = options.contentType.toString()
-      ..queryParameters = options.queryParameters;
+      ..queryParameters = uri.queryParameters;
 
     call
       ..request = request


### PR DESCRIPTION
options.queryParameters is used by Dio to offer an entrypoint for developpers to give query parameters easily.

options.queryParameters didn't contain queryParameters put inside path string : 

```dart
Dio().get(
  "https://test.com/home?test=youWillNotSeeMe", 
  queryParameters: {
    "test2: youWillSeeMe",
  },
);
```

`uri.queryParameters` contain both (path.queryParameters and options.queryParameters). This PR fix that and this issue : https://github.com/jhomlala/alice/issues/237