### PR TITLE
Fix Shaking for iOS

### DIFF
--- a/packages/alice/lib/core/alice_core.dart
+++ b/packages/alice/lib/core/alice_core.dart
@@ -43,7 +43,7 @@ class AliceCore {
       );
     }
     if (_configuration.showInspectorOnShake) {
-      if (OperatingSystem.isAndroid || OperatingSystem.isMacOS) {
+      if (OperatingSystem.isAndroid || OperatingSystem.isIOS) {
         _shakeDetector = ShakeDetector.autoStart(
           onPhoneShake: navigateToCallListScreen,
           shakeThresholdGravity: 4,


### PR DESCRIPTION
# Fix Shaking
Shaking currently did not work on iOS. I suspect that MacOs was accidentally entered instead of isIOS in the adjusted line during refactoring.

See #246 