### PR TITLE
fix(alice): Preserve search list by storing a copy instead of clearing

### DIFF
--- a/packages/alice/lib/ui/calls_list/widget/alice_inspector_screen.dart
+++ b/packages/alice/lib/ui/calls_list/widget/alice_inspector_screen.dart
@@ -39,7 +39,9 @@ class _AliceInspectorScreenState extends State<AliceInspectorScreen>
     return StreamBuilder<List<AliceHttpCall>>(
       stream: widget.aliceCore.callsStream,
       builder: (context, AsyncSnapshot<List<AliceHttpCall>> snapshot) {
-        final List<AliceHttpCall> calls = snapshot.data ?? [];
+        final List<AliceHttpCall> calls = snapshot.data != null ? [
+          ...?snapshot.data
+        ] : [];
         final String query = widget.queryTextEditingController.text.trim();
         if (query.isNotEmpty) {
           calls.removeWhere(


### PR DESCRIPTION
Fix: Preserve search list in Alice by storing a copy