### PR TITLE
Fix copying http request headers

### DIFF
--- a/packages/alice_http_client/lib/alice_http_client_adapter.dart
+++ b/packages/alice_http_client/lib/alice_http_client_adapter.dart
@@ -38,10 +38,10 @@ class AliceHttpClientAdapter with AliceAdapter {
         ..body = body;
     }
     httpRequest.time = DateTime.now();
-    final headers = <String, dynamic>{};
+    final headers = <String, String>{};
 
-    httpRequest.headers.forEach((header, dynamic value) {
-      headers[header] = value;
+    request.headers.forEach((header, values) {
+      headers[header] = values.toString();
     });
 
     httpRequest.headers = AliceParser.parseHeaders(headers: headers);


### PR DESCRIPTION
Resolves #257.

`httpRequest.headers` is empty here (since it was just initialized), we should probably copy the headers from `request.headers`.