### PR TITLE
Fix : Null check operator used on a null value

### DIFF
--- a/packages/alice/lib/core/alice_core.dart
+++ b/packages/alice/lib/core/alice_core.dart
@@ -68,10 +68,11 @@ class AliceCore {
 
   /// Called when calls has been updated
   Future<void> _onCallsChanged(List<AliceHttpCall>? calls) async {
-    if (calls != null && calls.isNotEmpty) {
+    final BuildContext? context = getContext();
+    if (calls != null && calls.isNotEmpty && context != null) {
       final AliceStats stats = _configuration.aliceStorage.getStats();
       _notification?.showStatsNotification(
-        context: getContext()!,
+        context: context,
         stats: stats,
       );
     }


### PR DESCRIPTION
This pull request makes a small improvement to the notification logic in `AliceCore`. The change ensures that a valid `BuildContext` is available before showing stats notifications, which helps prevent potential null reference errors.

Logs :

```
I/flutter ( 4362): ----------------FIREBASE CRASHLYTICS----------------
I/flutter ( 4362): Null check operator used on a null value
I/flutter ( 4362): #0      AliceCore._onCallsChanged (package:alice/core/alice_core.dart:74:30)
alice_core.dart:74
I/flutter ( 4362): #1      _RootZone.runUnaryGuarded (dart:async/zone.dart:1778:10)
zone.dart:1778
I/flutter ( 4362): #2      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:381:11)
stream_impl.dart:381
I/flutter ( 4362): #3      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:312:7)
stream_impl.dart:312
I/flutter ( 4362): #4      _MultiStreamController.addSync (dart:async/stream_impl.dart:1195:36)
stream_impl.dart:1195
I/flutter ( 4362): #5      _MultiControllerSink.add (package:rxdart/src/utils/forwarding_stream.dart:135:35)
forwarding_stream.dart:135
I/flutter ( 4362): #6      _StartWithStreamSink.onData (package:rxdart/src/transformers/start_with.dart:12:31)
start_with.dart:12
I/flutter ( 4362): #7      _RootZone.runUnaryGuarded (dart:async/zone.dart:1778:10)
zone.dart:1778
I/flutter ( 4362): #8      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:381:11)
stream_impl.dart:381
I/flutter ( 4362): #9      _DelayedData.perform (dart:async/stream_impl.dart:573:14)
stream_impl.dart:573
I/flutter ( 4362): #10     _PendingEvents.handleNext (dart:async/stream_impl.dart:678:11)
stream_impl.dart:678
I/flutter ( 4362): #11     _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:649:7)
stream_impl.dart:649
I/flutter ( 4362): #12     _microtaskLoop (dart:async/schedule_microtask.dart:40:35)
schedule_microtask.dart:40
I/flutter ( 4362): #13     _startMicro
I/flutter ( 4362): ----------------------------------------------------
```