### PR TITLE
Feat: Separate between notification small and large icons

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -51,13 +51,26 @@ default disabled):
 Alice alice = Alice(configuration: AliceConfiguation(showInspectorOnShake: true));
 ```
 
-If you want to pass another notification icon, you can use `notificationIcon` parameter. Default
-value is @mipmap/ic_launcher.
+If you want to pass another notification icon, you can use `notificationIcon` parameter for the number 1 (small icon) or `notificationLargeIcon` parameter for the number 4 (large icon). Default
+value is @mipmap/ic_launcher for small icon.
+
+<div align="center">
+<img src="https://developer.android.com/static/images/ui/notifications/notification-callouts_2x.png" height="120px"/>
+
+*src: https://developer.android.com/develop/ui/views/notifications#Templates*
+
+</div>
 
 ```dart
 
-Alice alice = Alice(configuration: AliceConfiguration(notificationIcon: "myNotificationIconResourceName"));
+Alice alice = Alice(
+    configuration: AliceConfiguration(
+        notificationIcon: "myNotificationSmallIconResourceName",
+        notificationLargeIcon: "myNotificationLargeIconResourceName",
+    ),
+);
 ```
+
 
 If you want to change the Directionality of Alice, you can use the `directionality` parameter. If
 the parameter is set to null, the Directionality of the app will be used.

--- a/packages/alice/lib/core/alice_core.dart
+++ b/packages/alice/lib/core/alice_core.dart
@@ -39,6 +39,7 @@ class AliceCore {
       _notification = AliceNotification();
       _notification?.configure(
         notificationIcon: _configuration.notificationIcon,
+        notificationLargeIcon: _configuration.notificationLargeIcon,
         openInspectorCallback: navigateToCallListScreen,
       );
     }

--- a/packages/alice/lib/core/alice_notification.dart
+++ b/packages/alice/lib/core/alice_notification.dart
@@ -29,8 +29,18 @@ class AliceNotification {
 
   /// Configures local notifications with [notificationIcon] and
   /// [openInspectorCallback].
+  ///
+  /// [notificationIcon] is typically a **monochrome silhouette icon**
+  /// on a **transparent background**, used for small icon.
+  ///
+  /// [notificationLargeIcon] is optional, used for large icon.
+  /// Android official docs doesn't recommend to use app icon.
+  ///
+  /// See more for notificationIcon and notificationLargeIcon information:
+  /// https://developer.android.com/develop/ui/views/notifications#Templates
   void configure({
     required String notificationIcon,
+    String? notificationLargeIcon,
     required void Function() openInspectorCallback,
   }) {
     _openInspectorCallback = openInspectorCallback;
@@ -41,7 +51,10 @@ class AliceNotification {
         channelDescription: _channel,
         enableVibration: false,
         playSound: false,
-        largeIcon: DrawableResourceAndroidBitmap(notificationIcon),
+        largeIcon:
+            notificationLargeIcon != null
+                ? DrawableResourceAndroidBitmap(notificationLargeIcon)
+                : null,
       ),
       iOS: const DarwinNotificationDetails(presentSound: false),
     );

--- a/packages/alice/lib/model/alice_configuration.dart
+++ b/packages/alice/lib/model/alice_configuration.dart
@@ -22,6 +22,9 @@ class AliceConfiguration with EquatableMixin {
   /// Icon url for notification. Default value is '@mipmap/ic_launcher'.
   final String notificationIcon;
 
+  /// Large icon url for notification.
+  final String? notificationLargeIcon;
+
   /// Directionality of app. Directionality of the app will be used if set to
   /// null. Default value is null.
   final TextDirection? directionality;
@@ -42,6 +45,7 @@ class AliceConfiguration with EquatableMixin {
     this.showNotification = true,
     this.showInspectorOnShake = true,
     this.notificationIcon = '@mipmap/ic_launcher',
+    this.notificationLargeIcon,
     this.directionality,
     this.showShareButton = true,
     GlobalKey<NavigatorState>? navigatorKey,
@@ -57,6 +61,7 @@ class AliceConfiguration with EquatableMixin {
     bool? showNotification,
     bool? showInspectorOnShake,
     String? notificationIcon,
+    String? notificationLargeIcon,
     TextDirection? directionality,
     bool? showShareButton,
     AliceStorage? aliceStorage,
@@ -65,6 +70,7 @@ class AliceConfiguration with EquatableMixin {
     showNotification: showNotification ?? this.showNotification,
     showInspectorOnShake: showInspectorOnShake ?? this.showInspectorOnShake,
     notificationIcon: notificationIcon ?? this.notificationIcon,
+    notificationLargeIcon: notificationLargeIcon ?? this.notificationLargeIcon,
     directionality: directionality ?? this.directionality,
     showShareButton: showShareButton ?? this.showShareButton,
     navigatorKey: navigatorKey ?? this.navigatorKey,
@@ -77,6 +83,7 @@ class AliceConfiguration with EquatableMixin {
     showNotification,
     showInspectorOnShake,
     notificationIcon,
+    notificationLargeIcon,
     directionality,
     showShareButton,
     navigatorKey,


### PR DESCRIPTION
This PR brings enhancement on how local notification be shown. Based on https://developer.android.com/develop/ui/views/notifications#Templates there are small and large icons, which have different purpose and type.

The small icon is typically an app icon in monochrome silhouette on a transparent background for newer Android notification requirement, if not a monochrome it will be appeared with white blank icon in the notification center.

And the large icon is an optional image that is typically used to convey message in a meaningful way.